### PR TITLE
Revert "Remove redundant pip downloads from README terminal commands"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ As previously stated, the application will recognize the following and send aler
 Use pip to install the required libraries. In your terminal or command prompt run:
 
 ```bash
-pip install pyautogui easyocr numpy requests pydirectinput
+pip install pyautogui easyocr numpy requests time re logging io json pydirectinput threading
 ```
 or
 ```bash
-py -m pip install pyautogui easyocr numpy requests pydirectinput
+py -m pip install pyautogui easyocr numpy requests time re logging io json pydirectinput threading
 ```
 ---
 


### PR DESCRIPTION
This will be fixed in v2.1
Just trying to cleanup the pull requests